### PR TITLE
Fix search

### DIFF
--- a/src/bridge/hyper.rs
+++ b/src/bridge/hyper.rs
@@ -131,6 +131,18 @@ pub trait AurRequester {
     /// [`Error::Uri`]: ../../enum.Error.html#variant.Uri
     fn aur_search_by(&self, query: &str, by: SearchBy)
         -> Box<Future<Item = Search<SearchResult>, Error = Error> + Send>;
+
+    fn aur_search(&self, query: &str)
+        -> Box<Future<Item = Search<SearchResult>, Error = Error> + Send>
+    {
+        self.aur_search_by(query, SearchBy::NameDesc)
+    }
+
+    fn aur_orphans(&self)
+        -> Box<Future<Item = Search<SearchResult>, Error = Error> + Send>
+    {
+        self.aur_search_by("", SearchBy::Maintainer)
+    }
 }
 
 impl<C> AurRequester for HyperClient<C, Body>

--- a/src/bridge/hyper.rs
+++ b/src/bridge/hyper.rs
@@ -12,7 +12,7 @@ use hyper::body::Body;
 use hyper::client::connect::Connect;
 use hyper::client::Client as HyperClient;
 use hyper::{Request, Uri};
-use model::{InfoResult, Search, SearchResult};
+use model::{InfoResult, Search, SearchBy, SearchResult};
 use serde_json;
 use std::fmt::{Display, Write};
 use std::str::FromStr;
@@ -129,7 +129,7 @@ pub trait AurRequester {
     /// [`Error::Hyper`]: ../../enum.Error.html#variant.Hyper
     /// [`Error::Json`]: ../../enum.Error.html#variant.Json
     /// [`Error::Uri`]: ../../enum.Error.html#variant.Uri
-    fn aur_search(&self, query: Option<&str>, maintainer: Option<&str>)
+    fn aur_search_by(&self, query: &str, by: SearchBy)
         -> Box<Future<Item = Search<SearchResult>, Error = Error> + Send>;
 }
 
@@ -159,20 +159,9 @@ impl<C> AurRequester for HyperClient<C, Body>
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
-    fn aur_search(&self, query: Option<&str>, maintainer: Option<&str>)
+    fn aur_search_by(&self, query: &str, by: SearchBy)
         -> Box<Future<Item = Search<SearchResult>, Error = Error> + Send + 'static> {
-        let mut url = format!("{}&type=search", API_URI);
-
-        if let Some(query) = query {
-            url.push_str("&arg=");
-            url.push_str(query);
-        }
-
-        if let Some(maintainer) = maintainer {
-            url.push_str("&maintainer=");
-            url.push_str(maintainer);
-        }
-
+        let url = format!("{}&type=search&arg={}&by={}", API_URI, query, by);
         let c = &url;
         let uri = ftry!(Uri::from_str(c));
 

--- a/src/bridge/reqwest.rs
+++ b/src/bridge/reqwest.rs
@@ -145,6 +145,19 @@ pub trait AurRequester {
     /// [`Error::Uri`]: ../../enum.Error.html#variant.Uri
     fn aur_search_by(&self, query: &str, by: SearchBy)
         -> Result<Search<SearchResult>>;
+
+    fn aur_search(&self, query: &str)
+        -> Result<Search<SearchResult>>
+    {
+        self.aur_search_by(query, SearchBy::NameDesc)
+    }
+
+    fn aur_orphans(&self)
+        -> Result<Search<SearchResult>>
+    {
+        self.aur_search_by("", SearchBy::Maintainer)
+    }
+
 }
 
 impl AurRequester for ReqwestClient {

--- a/src/bridge/reqwest.rs
+++ b/src/bridge/reqwest.rs
@@ -7,7 +7,7 @@
 //! [`AurRequester`]: trait.AurRequester.html
 
 use constants::API_URI;
-use model::{InfoResult, Search, SearchResult};
+use model::{InfoResult, Search, SearchBy, SearchResult};
 use std::fmt::{Display, Write};
 use std::io::Read;
 use reqwest::{Client as ReqwestClient, RequestBuilder, StatusCode, Url};
@@ -143,7 +143,7 @@ pub trait AurRequester {
     /// [`Error::ReqwestInvalid`]: ../../enum.Error.html#variant.ReqwestInvalid
     /// [`Error::ReqwestParse`]: ../../enum.Error.html#variant.ReqwestParse
     /// [`Error::Uri`]: ../../enum.Error.html#variant.Uri
-    fn aur_search(&self, query: Option<&str>, maintainer: Option<&str>)
+    fn aur_search_by(&self, query: &str, by: SearchBy)
         -> Result<Search<SearchResult>>;
 }
 
@@ -161,20 +161,9 @@ impl AurRequester for ReqwestClient {
         handle_request::<Search<InfoResult>>(&mut self.get(uri))
     }
 
-    fn aur_search(&self, query: Option<&str>, maintainer: Option<&str>)
+    fn aur_search_by(&self, query: &str, by: SearchBy)
         -> Result<Search<SearchResult>> {
-        let mut url = format!("{}&type=search", API_URI);
-
-        if let Some(query) = query {
-            url.push_str("&arg=");
-            url.push_str(query);
-        }
-
-        if let Some(maintainer) = maintainer {
-            url.push_str("&maintainer=");
-            url.push_str(maintainer);
-        }
-
+        let url = format!("{}&type=search&arg={}&by={}", API_URI, query, by);
         let uri = Url::parse(&url)?;
 
         handle_request::<Search<SearchResult>>(&mut self.get(uri))

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,33 @@
 //! Models mapping the API.
 
+use std::fmt;
+
+#[derive(Copy, Clone, Debug)]
+pub enum SearchBy {
+    Name,
+    NameDesc,
+    Maintainer,
+    Depends,
+    MakeDepends,
+    CheckDepends,
+    OptDepends,
+}
+
+impl fmt::Display for SearchBy {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str(match self {
+            SearchBy::Name => "name",
+            SearchBy::NameDesc => "name-desc",
+            SearchBy::Maintainer => "maintainer",
+            SearchBy::Depends => "depends",
+            SearchBy::MakeDepends => "makedepends",
+            SearchBy::OptDepends => "optdepends",
+            SearchBy::CheckDepends => "checkdepends",
+        })?;
+        Ok(())
+    }
+}
+
 /// Result data for a search.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Search<T: Send + Sync> {


### PR DESCRIPTION
the current implementation of aur_search states:

Searches for packages by a query, optionally filtering by maintainer
name.

This is untrue as &maintainer is not a valid argument. Instead
&by=maintainer should be used to search for a maintainer with the &arg=
becoming the maintainer to search for.

Additionally an empty query will return orphans. As appending "&arg="
still counts as an empty query, make query a &str and let the user
specify "" for orphans.

This patch implements &by= for all supported types. And renames the
method to aur_search_by.

Also added some extra methods for convenience 

Tests/examples/documentation has not yet been done. If you're happy with the code then I will update this PR before merging.